### PR TITLE
Rename shutdown() to dos_shutdown() (Fixes #2)

### DIFF
--- a/source/burn.c
+++ b/source/burn.c
@@ -152,7 +152,7 @@ int main( int argc, char* argv[] ) {
 
   memset(Scr,0,screenwidth()*screenheight()); /* Clear Screen */
 
-  while( !shutdown() && !keystate( KEY_ESCAPE ) ) {
+  while( !dos_shutdown() && !keystate( KEY_ESCAPE ) ) {
     waitvbl();
     Ch = *readchars();
  

--- a/source/dos.h
+++ b/source/dos.h
@@ -38,7 +38,7 @@ void waitvbl( void );
 void setpal( int index, int r, int g, int b );
 void getpal( int index, int* r, int* g, int* b );
 
-int shutdown( void );
+int dos_shutdown( void );
 
 void cputs( char const* string );
 void textcolor( int color );
@@ -423,7 +423,7 @@ static void internals_destroy( void ) {
 }
 
 
-int shutdown( void ) {
+int dos_shutdown( void ) {
     return thread_atomic_int_load( &internals->exit_flag );
 }
 

--- a/source/julia.c
+++ b/source/julia.c
@@ -48,7 +48,7 @@ int main(int argc, char *argv[])
         newIm = 2 * oldRe * oldIm + cIm;
         //if the point is outside the circle with radius 2: stop
         if((newRe * newRe + newIm * newIm) > 4) break;
-        if( keystate( KEY_ESCAPE ) || shutdown() ) exit(0);
+        if( keystate( KEY_ESCAPE ) || dos_shutdown() ) exit(0);
       }
       //draw the pixel
       putpixel(x, y, ( i + 32 ) & 255 );

--- a/source/mandelbrot.c
+++ b/source/mandelbrot.c
@@ -47,7 +47,7 @@ int main(int argc, char *argv[])
       }
       //draw the pixel
       putpixel(x, y, ( i + 32 ) & 255 );
-      if( keystate( KEY_ESCAPE ) || shutdown() ) exit(0);
+      if( keystate( KEY_ESCAPE ) || dos_shutdown() ) exit(0);
     }
     swapbuffers();
     zoom += zoomSpd;

--- a/source/plasma.c
+++ b/source/plasma.c
@@ -45,7 +45,7 @@ int main(int argc, char *argv[])
   unsigned char* buffer = screenbuffer();
 
   //start the animation loop, it rotates the palette
-  while(!shutdown())
+  while(!dos_shutdown())
   {
     waitvbl();
 

--- a/source/raycast.c
+++ b/source/raycast.c
@@ -174,7 +174,7 @@ int main(int argc, char* argv[])
    uint8_t* buffer = screenbuffer();
 
   //start the main loop
-  while(!shutdown())
+  while(!dos_shutdown())
   {
     waitvbl();
 #if FLOOR_HORIZONTAL

--- a/source/rotozoom.c
+++ b/source/rotozoom.c
@@ -22,7 +22,7 @@ int main( int argc, char *argv[] ) {
 
     unsigned char* buffer = screenbuffer();
     int angle = 0.0f;
-    while( !shutdown() ) {
+    while( !dos_shutdown() ) {
         waitvbl();
         float s = (float)sin( angle * PI / 180.0f );
         float c = (float)cos( angle * PI / 180.0f );

--- a/source/sound.c
+++ b/source/sound.c
@@ -24,7 +24,7 @@ int main( int argc, char* argv[] ) {
     gotoxy( 0, 11 ); cputs( "0 - Sound mode 5khz 8bit mono" );
     gotoxy( 0, 13 ); cputs( "ESC - quit" );
     cursoff();
-    while( !shutdown() ) {
+    while( !dos_shutdown() ) {
         char key = *readchars();
         if( key == '1' ) {
             playmusic( mid, 0, 255 );

--- a/source/stranded.c
+++ b/source/stranded.c
@@ -430,7 +430,7 @@ char const* dialogline( void ) {
 void wait( int jiffys ) {
     for( int i = 0; i < jiffys; ++i ) {
         waitvbl();
-    	if( shutdown() || *readkeys() == KEY_ESCAPE ) break;
+    	if( dos_shutdown() || *readkeys() == KEY_ESCAPE ) break;
         drawsprites();
         swapbuffers();
     }
@@ -539,7 +539,7 @@ void title_screen( void ) {
     int credits_delay = 30;
     int credits_move = 0;
 
-	while( !shutdown() ) {
+	while( !dos_shutdown() ) {
         waitvbl();
 		if( keystate( KEY_ESCAPE ) ) break; 
 		if( keystate( KEY_SPACE ) ) return;
@@ -655,7 +655,7 @@ int main( int argc, char* argv[] ) {
 
     float anim = 0.0f;
 
-	while( !shutdown() && !keystate( KEY_ESCAPE ) ) {
+	while( !dos_shutdown() && !keystate( KEY_ESCAPE ) ) {
 		for( int i = 0; i < objects_count; ++i )
             sprite_origin( objects[ i ], xpos, 0 );
 

--- a/source/tracker.c
+++ b/source/tracker.c
@@ -1299,7 +1299,7 @@ int main( int argc, char* argv[] ) {
 
     struct tracker_t* tracker = tracker_create();
    
-    while( !shutdown() ) {
+    while( !dos_shutdown() ) {
         waitvbl();
         
         tracker_update_play( tracker, 1000000 / 60 );

--- a/source/tunnel.c
+++ b/source/tunnel.c
@@ -54,7 +54,7 @@ int main(int argc, char *argv[])
   unsigned char* buffer = screenbuffer();
 
   //begin the loop
-  while(!shutdown())
+  while(!dos_shutdown())
   {
     waitvbl();     
     animation += 1.0f / 60.0f;

--- a/source/voxel.c
+++ b/source/voxel.c
@@ -33,7 +33,7 @@ int main( int argc, char* argv[] ) {
     setdoublebuffer( 1 );
     uint8_t* screen = screenbuffer();
 
-    while( !shutdown() ) {
+    while( !dos_shutdown() ) {
         waitvbl();
         clearscreen();        
 


### PR DESCRIPTION
On Linux (and Unix-like operating systems), `shutdown` is the name of a function to shut down part of a full-duplex connection (sockets). The public, unmangled C function `shutdown` in `dos.h` clashes with this, resulting in #2. A fix is to just rename it. With careful use of the `static` keyword (so the `shutdown` symbol isn't exported) this could be worked around, but this is just more foolproof IMHO.

Feel free to bikeshed on the name and/or rename it yourself :)