### PR TITLE
support readchars() on SDL builds

### DIFF
--- a/source/libs/app.h
+++ b/source/libs/app.h
@@ -3645,6 +3645,17 @@ app_state_t app_yield( app_t* app )
             input_event.data.key = app_internal_scancode_to_appkey( app, e.key.keysym.scancode );
             app_internal_add_input_event( app, &input_event );
             }
+        else if( e.type == SDL_TEXTINPUT )
+            {
+            app_input_event_t input_event;
+            char *c;
+            input_event.type = APP_INPUT_CHAR;
+            for ( c = e.text.text; *c; c++ )
+                {
+                input_event.data.char_code = *c;
+                app_internal_add_input_event( app, &input_event );
+                }
+            }
         else if( e.type == SDL_MOUSEMOTION )
             {
             app_input_event_t input_event;


### PR DESCRIPTION
Hi Mattias,

I fixed the readchars() SDL problem so I could extinguish the fire in the burn example program. 
The sound example (mentioned in #29) works now too.
Tested on Ubuntu.

Sam

--------------------------------

In the libs/app.h event processing for SDL, APP_INPUT_CHAR events were not
being generated so dos.h's readchars() would never return any data.
As a result, the burn and sound example programs would not respond to
user input.

The SDL_TEXTINPUT SDL event appears to be the appropriate SDL event to drive
the APP_INPUT_CHAR app events.